### PR TITLE
Update listitem.py

### DIFF
--- a/resources/modules/infotagger/listitem.py
+++ b/resources/modules/infotagger/listitem.py
@@ -11,6 +11,8 @@ class ListItemInfoTag():
         'video': {
             'tag_getter': 'getVideoInfoTag',
             'tag_attr': {
+                'size': {'attr': 'setInfo', 'convert': int, 'classinfo': int},
+                'count': {'attr': 'setInfo', 'convert': int, 'classinfo': int},
                 'genre': {'attr': 'setGenres', 'convert': lambda x: [x], 'classinfo': (list, tuple)},
                 'country': {'attr': 'setCountries', 'convert': lambda x: [x], 'classinfo': (list, tuple)},
                 'year': {'attr': 'setYear', 'convert': int, 'classinfo': int},
@@ -58,7 +60,7 @@ class ListItemInfoTag():
                 'path': {'attr': 'setPath', 'convert': str, 'classinfo': str},
                 'trailer': {'attr': 'setTrailer', 'convert': str, 'classinfo': str},
                 'dateadded': {'attr': 'setDateAdded', 'convert': str, 'classinfo': str},
-                'date': {'attr': 'setDateAdded', 'convert': str, 'classinfo': str},
+                'date': {'attr': 'setInfo', 'convert': str, 'classinfo': str},
                 'mediatype': {'attr': 'setMediaType', 'convert': str, 'classinfo': str},
                 'dbid': {'attr': 'setDbId', 'convert': int, 'classinfo': int},
             }
@@ -66,6 +68,9 @@ class ListItemInfoTag():
         'music': {
             'tag_getter': 'getMusicInfoTag',
             'tag_attr': {
+                'size': {'attr': 'setInfo', 'convert': int, 'classinfo': int},
+                'count': {'attr': 'setInfo', 'convert': int, 'classinfo': int},
+                'date': {'attr': 'setInfo', 'convert': str, 'classinfo': str},
                 'tracknumber': {'attr': 'setTrack', 'convert': int, 'classinfo': int},
                 'discnumber': {'attr': 'setDisc', 'convert': int, 'classinfo': int},
                 'duration': {'attr': 'setDuration', 'convert': int, 'classinfo': int},
@@ -93,6 +98,9 @@ class ListItemInfoTag():
         'game': {
             'tag_getter': 'getGameInfoTag',
             'tag_attr': {
+                'size': {'attr': 'setInfo', 'convert': int, 'classinfo': int},
+                'count': {'attr': 'setInfo', 'convert': int, 'classinfo': int},
+                'date': {'attr': 'setInfo', 'convert': str, 'classinfo': str},
                 'title': {'attr': 'setTitle', 'convert': str, 'classinfo': str},
                 'platform': {'attr': 'setPlatform', 'convert': str, 'classinfo': str},
                 'genres': {'attr': 'setGenres', 'convert': lambda x: [x], 'classinfo': (list, tuple)},
@@ -131,10 +139,16 @@ class ListItemInfoTag():
                 continue
             try:
                 _tag_attr = self._tag_attr[k]
-                func = getattr(self._info_tag, _tag_attr['attr'])
-                if self._type_chk and not isinstance(v, _tag_attr['classinfo']):
-                    raise TypeError
-                func(v)
+                if _tag_attr.get('attr') == 'setInfo':
+                    func = getattr(self._listitem, _tag_attr['attr'])
+                    if self._type_chk and not isinstance(v, _tag_attr['classinfo']):
+                        raise TypeError
+                    func(self._tag_type,{k:v})
+                else:
+                    func = getattr(self._info_tag, _tag_attr['attr'])
+                    if self._type_chk and not isinstance(v, _tag_attr['classinfo']):
+                        raise TypeError
+                    func(v)
 
             except KeyError:
                 if k not in self._tag_attr:


### PR DESCRIPTION
Attempt to add callback to setinfo for the 3 General Values that apply to all types.  Currently no setter is available for these keys.  Ref https://github.com/xbmc/xbmc/issues/22752

Please take a look and review.  I tried to find a more pythonic way to add a custom attribute using python to the getInfoVideoTag and similar objects, but couldn't find a good way.  This seemed like the simplest (hopefully temporary) method.

Specifically with 'date' I wasnt sure what to do.  I'm not sure the difference under the hood in 'date' and 'dateAdded'