### PR TITLE
Update set_resume_point to handle str typed properties

### DIFF
--- a/resources/modules/infotagger/listitem.py
+++ b/resources/modules/infotagger/listitem.py
@@ -200,8 +200,8 @@ class _ListItemInfoTagVideo(_ListItemInfoTag):
     def set_resume_point(self, infoproperties: dict, resume_key='ResumeTime', total_key='TotalTime', pop_keys=True):
         """ Wrapper to get/pop resumetime and totaltime properties for InfoTagVideo.setResumePoint() """
         getter_func = infoproperties.pop if pop_keys else infoproperties.get
-        resume_time = getter_func(resume_key, None)
-        total_time = getter_func(total_key, None)
+        resume_time = int(getter_func(resume_key, 0))
+        total_time = int(getter_func(total_key, 0))
         if resume_time and total_time:
             self._info_tag.setResumePoint(resume_time, total_time)
         elif resume_time:

--- a/resources/modules/infotagger/listitem.py
+++ b/resources/modules/infotagger/listitem.py
@@ -200,8 +200,14 @@ class _ListItemInfoTagVideo(_ListItemInfoTag):
     def set_resume_point(self, infoproperties: dict, resume_key='ResumeTime', total_key='TotalTime', pop_keys=True):
         """ Wrapper to get/pop resumetime and totaltime properties for InfoTagVideo.setResumePoint() """
         getter_func = infoproperties.pop if pop_keys else infoproperties.get
-        resume_time = int(getter_func(resume_key, 0))
-        total_time = int(getter_func(total_key, 0))
+        try:
+            resume_time = float(getter_func(resume_key, 0.0))
+        except ValueError:
+            resume_time = None
+        try:
+            total_time = float(getter_func(total_key, 0.0))
+        except ValueError:
+            total_time = None
         if resume_time and total_time:
             self._info_tag.setResumePoint(resume_time, total_time)
         elif resume_time:


### PR DESCRIPTION
Hey mate,

Hope all is well. Ran across a small problem when trying to use `set_resume_point`, thought I would just create a quick run-by PR rather than an issue.

In Kodi 20+, when passing a properties dict intended for use in Kodi 19 or below as a parameter to `set_resume_point`, typically the `ResumeTime` and `TotalTime` properties will be a `str` type value as the `SetProperty` and `SetProperties` methods require the property values to be `unicode` or `str`.

This causes `setResumePoint` to fail as it expects the parameter values to be `float` or `int`.

This PR coerces the extracted `ResumeTime` and `TotalTime` properties to be `float` type values.