### PR TITLE
Fix 'date' info label not being set on underlying ListItem

### DIFF
--- a/resources/modules/infotagger/listitem.py
+++ b/resources/modules/infotagger/listitem.py
@@ -76,7 +76,7 @@ class _ListItemInfoTag():
                 continue
 
             except KeyError:
-                if _tag_attr.get('skip'):
+                if 'skip' in _tag_attr:
                     continue
 
                 if 'route' in _tag_attr:
@@ -91,13 +91,17 @@ class _ListItemInfoTag():
             except TypeError:
                 func(_tag_attr['convert'](v))  # Attempt to force conversion to correct type
 
+    def set_datetime(self, label: str, *args, **kwargs):
+        """ Wrapper for ListItem.setInfo() to ListItem.setDateTime() """
+        self._listitem.setDateTime(label)
+
 
 class _ListItemInfoTagVideo(_ListItemInfoTag):
     _tag_gttr = 'getVideoInfoTag'
     _tag_attr = {
         'size': {'skip': True},  # Currently no infoTag setter for this property
         'count': {'skip': True},  # Currently no infoTag setter for this property
-        'date': {'attr': 'setDateAdded', 'convert': str, 'classinfo': str},  # Unsure if this is the correct place to route this generic value
+        'date': {'route': 'set_datetime'},
         'genre': {'attr': 'setGenres', 'convert': lambda x: [x], 'classinfo': (list, tuple)},
         'country': {'attr': 'setCountries', 'convert': lambda x: [x], 'classinfo': (list, tuple)},
         'year': {'attr': 'setYear', 'convert': int, 'classinfo': int},


### PR DESCRIPTION
`ListItem.setInfo({'date': '2000-01-01'})` is not deprecated and should update the date on the `ListItem`: https://github.com/xbmc/xbmc/blob/master/xbmc/interfaces/legacy/ListItem.cpp#L399-L400

This is equivalent to using `ListItem.setDateTime('2000-01-01')`: https://github.com/xbmc/xbmc/blob/master/xbmc/interfaces/legacy/ListItem.cpp#L121-L130

Current code instead calls the `setDateAdded` method of the `ListItemInfoTag` which breaks sorting a directory listing by date in Kodi